### PR TITLE
build: fix ci to run tests on main push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
   test:
     needs: changes
     # always run the tests on push to main
-    if: ${{ needs.changes.outputs.dart == 'true' || needs.changes.result == 'skipped' }}
+    if: ${{ always() && (needs.changes.outputs.dart == 'true' || needs.changes.result == 'skipped') }}
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
