### PR TITLE
build: add more path filters to ci flow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,8 @@ jobs:
             dart:
              - 'lib/**'
              - 'test/**'
+             - 'testing/**'
+             - 'pubspec.yaml'
 
   test:
     needs: changes


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
