### PR TITLE
test: return error when article loading fails

### DIFF
--- a/lib/data/repository.dart
+++ b/lib/data/repository.dart
@@ -42,7 +42,7 @@ class CacheRepository implements Repository {
       if (result.isError()) {
         final err = result.exceptionOrNull();
         log('error loading articles for category: ${model.name} in file ${model.file}: $err');
-        // TODO: return Failure();
+        return Future.value(Failure(err!));
       }
 
       final articles = result.getOrNull() ?? [];
@@ -58,6 +58,11 @@ class CacheRepository implements Repository {
 
   AsyncResult<List<Article>> _loadArticles(CategoryModel category) async {
     final result = await _service.fetchArticles(category);
+    if (result.isError()) {
+      final err = result.exceptionOrNull();
+      return Future.value(Failure(err!));
+    }
+
     final models = result.getOrNull() ?? [];
     if (models.isEmpty) {
       log('no articles found via service for category: ${category.name} in file ${category.file}');

--- a/test/data/repository_test.dart
+++ b/test/data/repository_test.dart
@@ -56,7 +56,7 @@ void main() {
       });
 
       when('the repository fails to load', () {
-        final service = FakeService(fail: true);
+        final service = FakeService(Fail.categories);
         final repository = CacheRepository(service);
         late Result<List<Category>> result;
 
@@ -87,7 +87,7 @@ void main() {
           fetched.addAll(categories!);
 
           // Verify the cache by forcing the service to error.
-          service.fail = true;
+          service.fail = Fail.categories;
           result = await repository.loadCategories();
           result.isSuccess().should.beTrue();
           final cachedCategories = result.getOrNull();

--- a/test/data/repository_test.dart
+++ b/test/data/repository_test.dart
@@ -55,7 +55,7 @@ void main() {
         });
       });
 
-      when('the repository fails to load', () {
+      when('the repository fails to load categories', () {
         final service = FakeService(Fail.categories);
         final repository = CacheRepository(service);
         late Result<List<Category>> result;
@@ -68,6 +68,23 @@ void main() {
         then('a failure is returned', () {
           final failure = result.exceptionOrNull();
           failure.should.not.beNull();
+        });
+      });
+
+      when('the repository fails to load articles', () {
+        final service = FakeService(Fail.articles);
+        final repository = CacheRepository(service);
+        late Result<List<Category>> result;
+
+        before(() async {
+          result = await repository.loadCategories();
+          result.isError().should.beTrue();
+        });
+
+        then('a failure is returned', () {
+          final failure = result.exceptionOrNull();
+          failure.should.not.beNull();
+          failure.toString().contains('articles').should.beTrue();
         });
       });
 

--- a/testing/service.dart
+++ b/testing/service.dart
@@ -23,20 +23,39 @@ class FakeLoader implements AssetLoader {
   }
 }
 
-class FakeService implements Service {
-  bool fail;
+/// Enum to determine fail state for testing purposes.
+enum Fail {
+  none,
+  categories,
+  articles,
+  all;
 
-  FakeService({this.fail = false});
+  bool get forArticles => this == Fail.articles || this == Fail.all;
+}
+
+class FakeService implements Service {
+  Fail fail;
+
+  FakeService([this.fail = Fail.none]);
 
   @override
   AsyncResult<List<CategoryModel>> fetchCategories() {
-    return fail
-        ? Future.value(Failure(Exception('failed to fetch categories')))
-        : Future.value(Success(kCategoryModels));
+    final e = Exception('failed to fetch categories');
+
+    return switch (fail) {
+      Fail.categories || Fail.all => Future.value(Failure(e)),
+      _ => Future.value(Success(kCategoryModels)),
+    };
   }
 
   @override
   AsyncResult<List<ArticleModel>> fetchArticles(CategoryModel category) {
+    if (fail.forArticles) {
+      final e = Exception('failed to fetch articles');
+
+      return Future.value(Failure(e));
+    }
+
     return switch (category.name) {
       kWorldCategory => Future.value(Success(kArticleModels)),
       _ => Future.value(Success([])),


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
