### PR TITLE
fix: adjust bottom sheet padding for newer iphones

### DIFF
--- a/lib/ui/articles_view.dart
+++ b/lib/ui/articles_view.dart
@@ -149,7 +149,7 @@ class _DetailView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      height: MediaQuery.of(context).size.height * 0.95,
+      height: MediaQuery.of(context).size.height - kToolbarHeight,
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.only(
@@ -218,17 +218,21 @@ class _DetailView extends StatelessWidget {
                       Spacing.s24,
                       _FactCard(article.fact),
                       Spacing.s24,
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          FilledButton(
-                            child: Text(_buttonCloseText),
-                            onPressed: () {
-                              onChanged(article.id, true);
-                              Navigator.of(context).pop();
-                            },
-                          ),
-                        ],
+                      Padding(
+                        padding: EdgeInsets.only(
+                            bottom: MediaQuery.of(context).viewPadding.bottom),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            FilledButton(
+                              child: Text(_buttonCloseText),
+                              onPressed: () {
+                                onChanged(article.id, true);
+                                Navigator.of(context).pop();
+                              },
+                            ),
+                          ],
+                        ),
                       ),
                       Spacing.s8,
                     ],


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
